### PR TITLE
fix(lectures): add GitHub authentication section for Google Colaboratory

### DIFF
--- a/book/lectures/softeng/vcs/03_publishing.ipynb
+++ b/book/lectures/softeng/vcs/03_publishing.ipynb
@@ -102,6 +102,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## GitHub authentication for Google Colaboratory\n",
+    "\n",
+    "To authenticate with GitHub, we need to generate a [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) (PAT).\n",
+    "\n",
+    "- Go to your GitHub account settings page, select \"Developer settings\", then \"Personal access tokens\", then \"Generate new token\".\n",
+    "- Give the token a description like \"Colaboratory access\" and select the scopes/permissions as needed for your usage.\n",
+    "- Copy the token to your clipboard.\n",
+    "\n",
+    "  **Note that this token is like a password, so keep it secret!**\n",
+    "\n",
+    "For the Korean explanation, see [here](https://velog.io/@shong676/Colab%EA%B3%BC-GitHub-%EC%97%B0%EB%8F%99%ED%95%98%EA%B8%B0).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Adding a new remote to your repository\n",
     "\n",
     "Instructions will appear, once you've created the repository, as to how to add this new \"remote\" server to your repository.\n",


### PR DESCRIPTION

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>