### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/book/lectures/llms/agents/autogen.md
+++ b/book/lectures/llms/agents/autogen.md
@@ -13,28 +13,28 @@ AutoGen, developed by Microsoft in collaboration with Penn State University and 
   It's advisable to create a virtual environment to keep AutoGen's dependencies isolated. Two options are available: `venv` and `conda`. Here are the commands for each:
   - Using `venv`:
     ```bash
-    python3 -m venv pyautogen
-    source pyautogen/bin/activate
+    python3 -m venv ag2
+    source ag2/bin/activate
     deactivate  # to deactivate the environment
     ```
   - Using `conda`:
     ```bash
-    conda create -n pyautogen python=3.10  # python 3.10 is recommended
-    conda activate pyautogen
+    conda create -n ag2 python=3.10  # python 3.10 is recommended
+    conda activate ag2
     conda deactivate  # to deactivate the environment
     ```
 - **Python and AutoGen Installation**:
   Ensure you have Python version >= 3.8. Install AutoGen using pip:
   ```bash
-  pip install pyautogen
+  pip install ag2
   ```
 - **Optional Dependencies**:
   Install additional packages based on your requirements:
   ```bash
   pip install docker  # for seamless code execution
-  pip install "pyautogen[blendsearch]"  # for hyperparameter optimization
-  pip install "pyautogen[retrievechat]"  # for retrieval-augmented generation tasks
-  pip install "pyautogen[mathchat]"  # for math problem solving
+  pip install "ag2[blendsearch]"  # for hyperparameter optimization
+  pip install "ag2[retrievechat]"  # for retrieval-augmented generation tasks
+  pip install "ag2[mathchat]"  # for math problem solving
   ```
 
 ## Framework Overview


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
